### PR TITLE
Reverts ac7a0ab change to eventlog

### DIFF
--- a/eventloghook.go
+++ b/eventloghook.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package eventloghook
@@ -7,16 +8,16 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/windows/svc/eventlog"
+	"golang.org/x/sys/windows/svc/debug"
 )
 
 // EventLogHook to send logs via windows log.
 type EventLogHook struct {
-	upstream eventlog.Log
+	upstream debug.Log
 }
 
-// NewHook creates and returns a new EventLogHook wrapped around anything that implements the eventlog.Log interface
-func NewHook(logger eventlog.Log) *EventLogHook {
+// NewHook creates and returns a new EventLogHook wrapped around anything that implements the debug.Log interface
+func NewHook(logger debug.Log) *EventLogHook {
 	return &EventLogHook{upstream: logger}
 }
 

--- a/eventloghook_test.go
+++ b/eventloghook_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package eventloghook


### PR DESCRIPTION
This reverts the unintended change that resulted in a breaking change by using a different log receiver

Also adds modern go build directives