### PR TITLE
feat-logger: Use a logging interface, fix tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,13 @@ func main() {
   log.Hooks.Add(eventloghook.NewHook(elog))
 }
 ```
+
+
+## Breaking Changes
+
+* 2025-06-04 - Added support for Trace log level, better late than never.
+Only a concern if you're relying on the event ID for filtering or reporting.
+Changes:
+   * logrus.InfoLevel used to be EID 2 is now EID 3
+   * logrus.DebugLevel used to be EID 1 is now EID 2
+   * logrus.TraceLevel never existed but is now EID 1

--- a/eventloghook.go
+++ b/eventloghook.go
@@ -12,15 +12,15 @@ import (
 
 // EventLogHook to send logs via windows log.
 type EventLogHook struct {
-	upstream logger
+	upstream Logger
 }
 
-// NewHook creates and returns a new EventLogHook wrapped around anything that implements the logger interface
+// NewHook creates and returns a new EventLogHook wrapped around anything that implements the Logger interface
 // for example:
 // * golang.org/x/sys/windows/svc/eventlog.Log
 // * golang.org/x/sys/windows/svc/debug.Log
-func NewHook(logger logger) *EventLogHook {
-	return &EventLogHook{upstream: logger}
+func NewHook(Logger Logger) *EventLogHook {
+	return &EventLogHook{upstream: Logger}
 }
 
 func (hook *EventLogHook) Fire(entry *logrus.Entry) error {
@@ -40,8 +40,10 @@ func (hook *EventLogHook) Fire(entry *logrus.Entry) error {
 	case logrus.WarnLevel:
 		return hook.upstream.Warning(1, line)
 	case logrus.InfoLevel:
-		return hook.upstream.Info(2, line)
+		return hook.upstream.Info(3, line)
 	case logrus.DebugLevel:
+		return hook.upstream.Info(2, line)
+	case logrus.TraceLevel:
 		return hook.upstream.Info(1, line)
 	default:
 		return nil

--- a/eventloghook.go
+++ b/eventloghook.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package eventloghook
@@ -7,16 +8,18 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/windows/svc/eventlog"
 )
 
 // EventLogHook to send logs via windows log.
 type EventLogHook struct {
-	upstream eventlog.Log
+	upstream logger
 }
 
-// NewHook creates and returns a new EventLogHook wrapped around anything that implements the eventlog.Log interface
-func NewHook(logger eventlog.Log) *EventLogHook {
+// NewHook creates and returns a new EventLogHook wrapped around anything that implements the logger interface
+// for example:
+// * golang.org/x/sys/windows/svc/eventlog.Log
+// * golang.org/x/sys/windows/svc/debug.Log
+func NewHook(logger logger) *EventLogHook {
 	return &EventLogHook{upstream: logger}
 }
 

--- a/eventloghook_test.go
+++ b/eventloghook_test.go
@@ -27,7 +27,7 @@ func TestEventLogAndPrint(t *testing.T) {
 	testTheInterface(t, elog)
 }
 
-func testTheInterface(t *testing.T, l logger) {
+func testTheInterface(t *testing.T, l Logger) {
 	log := logrus.New()
 	log.Hooks.Add(NewHook(l))
 

--- a/eventloghook_test.go
+++ b/eventloghook_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package eventloghook
@@ -7,19 +8,34 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows/svc/debug"
+	"golang.org/x/sys/windows/svc/eventlog"
 )
 
 func TestDebugLogAndPrint(t *testing.T) {
-	log := logrus.New()
-	elog = debug.New("ServiceName")
+	elog := debug.New("ServiceName")
 	defer elog.Close()
-	log.Hooks.Add(NewEventLogHook(elog))
 
-	for _, level := range hook.Levels() {
+	testTheInterface(t, elog)
+}
+
+func TestEventLogAndPrint(t *testing.T) {
+	elog, err := eventlog.Open("ServiceName")
+	if err != nil {
+		t.Errorf("Unexpected error %q while opening eventlog", err)
+	}
+
+	testTheInterface(t, elog)
+}
+
+func testTheInterface(t *testing.T, l logger) {
+	log := logrus.New()
+	log.Hooks.Add(NewHook(l))
+
+	for _, level := range logrus.AllLevels {
 		if len(log.Hooks[level]) != 1 {
-			t.Errorf("EventLogHook was not added. The length of log.Hooks[%v]: %v", level, len(log.Hooks[level]))
+			t.Errorf("Log was not added. The length of log.Hooks[%v]: %v", level, len(log.Hooks[level]))
 		}
 	}
 
-	log.Info("Congratulations!")
+	log.Infof("Congratulations (%T)!", l)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/freman/eventloghook
+
+go 1.24.3
+
+require (
+	github.com/sirupsen/logrus v1.9.3
+	golang.org/x/sys v0.33.0
+)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/freman/eventloghook
 
-go 1.24.3
+go 1.23.0
 
 require (
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
+golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,8 @@
+package eventloghook
+
+type logger interface {
+	Close() error
+	Error(eid uint32, msg string) error
+	Info(eid uint32, msg string) error
+	Warning(eid uint32, msg string) error
+}

--- a/logger.go
+++ b/logger.go
@@ -1,7 +1,6 @@
 package eventloghook
 
 type logger interface {
-	Close() error
 	Error(eid uint32, msg string) error
 	Info(eid uint32, msg string) error
 	Warning(eid uint32, msg string) error

--- a/logger.go
+++ b/logger.go
@@ -1,6 +1,13 @@
+//go:build windows
+// +build windows
+
 package eventloghook
 
-type logger interface {
+// Logger interface to cover the two common windows loggers
+// IE:
+// * golang.org/x/sys/windows/svc/eventlog.Log
+// * golang.org/x/sys/windows/svc/debug.Log
+type Logger interface {
 	Error(eid uint32, msg string) error
 	Info(eid uint32, msg string) error
 	Warning(eid uint32, msg string) error


### PR DESCRIPTION
Create harmony.
Do a little housework.

Introduce the logger interface that covers the best parts of both of the loggers provided by windows, and fixed the tests